### PR TITLE
Allow claude bot to trigger workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude[bot]'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## What problem(s) was I solving?

The Claude Code GitHub Action workflow was rejecting events initiated by the `claude[bot]` actor. When Claude created PRs or comments that triggered the workflow, the action would refuse to run because the bot wasn't in the allowed bots list. This meant Claude couldn't respond to its own PR activity or participate in follow-up interactions on PRs it created.

## What user-facing changes did I ship?

No user-facing application changes. This is a CI/CD configuration fix that allows the Claude Code Action to properly respond when triggered by `claude[bot]` events (e.g., comments on PRs created by Claude).

## How I implemented it

Added the `allowed_bots: 'claude[bot]'` parameter to the `anthropics/claude-code-action@v1` step in `.github/workflows/claude.yml`. This explicitly permits the workflow to process events originating from the Claude bot actor.

## How to verify it

### Manual Testing

- [ ] Tag `@claude` in a comment on a PR created by `claude[bot]` and verify the workflow runs successfully
- [ ] Confirm the workflow still triggers normally when a human user tags `@claude`

## Description for the changelog

Fixed Claude Code workflow to accept events from `claude[bot]`, allowing the action to respond on PRs and issues initiated by the bot.
