### PR TITLE
fix(ci): grant write permission to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- Changed `pull-requests: read` to `pull-requests: write` in the Claude Code Review workflow
- The review workflow was unable to post comments on PRs due to insufficient permissions

## Test plan
- [ ] Open a PR and verify the Claude Code Review workflow runs and posts review comments