### PR TITLE
fix(ci): enable code review comment posting on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
+          track_progress: true
+          use_sticky_comment: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Added `track_progress: true` to force "tag mode" — the action was silently using "agent mode" (which never posts PR comments) because a `prompt` input was provided
- Added `use_sticky_comment: true` to update the review comment in-place on re-pushes instead of creating duplicates

## Context
The code review workflow was running successfully and generating reports, but the output was only written to the GitHub Actions Step Summary. No comments were ever posted on PRs because agent mode is hard-coded to skip comment posting.

## Test plan
- [ ] Merge this PR, then open/push to another PR and verify a review comment appears