### PR TITLE
fix(ci): enable inline code review comments on PR files

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,5 +42,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Added `claude_args` with `--allowedTools` to grant Claude access to:
  - `mcp__github_inline_comment__create_inline_comment` — post inline comments on specific code lines in the "Files changed" tab
  - `Bash(gh pr diff:*)` and `Bash(gh pr view:*)` — read PR diff and metadata

## Context
After the previous fix (`track_progress: true`), reviews now post as conversation-level comments. This change enables inline comments directly on code lines for more actionable feedback.

## Test plan
- [ ] Merge this PR, then push to another open PR and verify inline comments appear in "Files changed"