### PR TITLE
fix(ci): add inline comment tool to @claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,4 +78,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
-            --allowedTools "Bash(npm:*),Bash(npx:*),Bash(cargo:*),Bash(gh:*),Bash(git:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(npm:*),Bash(npx:*),Bash(cargo:*),Bash(gh:*),Bash(git:*)"


### PR DESCRIPTION
## Summary
- Added `mcp__github_inline_comment__create_inline_comment` to the allowed tools in the `@claude` mention workflow
- This lets `@claude` post inline comments on specific code lines in the "Files changed" tab, matching the review workflow's capabilities

## Test plan
- [ ] Merge and mention `@claude` on a PR to verify inline comments work