### PR TITLE
fix(ci): use Opus model in Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,7 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,4 +78,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           claude_args: |
+            --model claude-opus-4-6
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(npm:*),Bash(npx:*),Bash(cargo:*),Bash(gh:*),Bash(git:*)"


### PR DESCRIPTION
## Summary
- Both CI workflows (`claude.yml` and `claude-code-review.yml`) defaulted to Sonnet 4.6 since no model was explicitly specified
- Added `--model claude-opus-4-6` to `claude_args` in both workflows

Closes #13